### PR TITLE
Add hint for selection highlight to work as in #4

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -512,6 +512,10 @@ class TEXTIFY_preferences(bpy.types.AddonPreferences):
             sub.label(text="Highlighting Behavior:")
             for prop in ["highlight_mode", "case_sensitive", "show_in_scroll"]:
                 sub.prop(self, prop)
+                if prop == "highlight_mode" and self.highlight_mode != "FIND_TEXT":
+                    sub.label(text="Selection highlight works best with an odd font size number in the text editor.",
+                              icon='WARNING_LARGE'
+                             )
 
             if self.show_in_scroll:
                 sub_box = box.box()
@@ -578,3 +582,4 @@ def unregister():
             print(f"Error unregistering class {getattr(cls, '__name__', cls)}: {e}")
 
     bpy.types.TEXT_HT_header.remove(draw_header)
+


### PR DESCRIPTION
As mentioned in #4 

It might be interesting to add a hint in the highlight occurrences settings that odd font numbers work best with this:

<img width="479" height="223" alt="image" src="https://github.com/user-attachments/assets/368089fe-f340-44f5-9ea0-56051ff6f535" />

Since I already coded that for the mockup, here's the code if you want it.